### PR TITLE
Make scripts compatible with Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,47 @@ for the [Benchmarking Metric Ground Navigation](https://arxiv.org/pdf/2008.13315
 to generate new datasets for robots of different footprints.
 
 ## Requirements
-* Python 2
+* Python 2 or Python 3
 * NumPy
 * Matplotlib
 
 ## Using this repository
 After cloning this repository onto your computer, create a folder called "test_data" in the same directory. Inside the test_data folder, create folders called cspace_files, grid_files, map_files, world_files, metrics_files, norm_metrics_files, and path_files.
 
+```console
+$ mkdir -p \
+  test_data/cspace_files \
+  test_data/grid_files \
+  test_data/map_files \
+  test_data/world_files \
+  test_data/metrics_files \
+  test_data/norm_metrics_files \
+  test_data/path_files
+```
+
 ### Generating a sample world
-Run gen_world_ca.py in Python 2. This will generate a 30x30 world by cellular automaton, using an initial fill percent of 0.2 and 4 smoothing iterations.
+Run gen_world_ca.py.
+
+```console
+$ python gen_world_ca.py
+```
+
+This will generate a 30x30 world by cellular automaton, using an initial fill percent of 0.2 and 4 smoothing iterations.
 The script will generate a path through this world and calculate difficulty metrics along this path. After this, it will save the metrics and representations of the world and path into the test_data folder. The sample world file names will be suffixed with "-1". This script can be modified to display the world, C-space, path, and the calculated metrics by uncommenting lines 683-693. To try out different generation parameters (rows, columns, fill percent, iterations), uncomment lines 569-573.
 
 ### Generating a new dataset
-Run generator.py in Python 2. This will generate 300 worlds with dimensions 30x30 using 12 different sets of cellular automaton parameters. These parameters can be changed within the generator.py script.
+Run generator.py.
+
+```console
+$ python generator.py
+```
+This will generate 300 worlds with dimensions 30x30 using 12 different sets of cellular automaton parameters. These parameters can be changed within the generator.py script.
 If you change the dimensions or radius of the cylinders, update the .yaml files or `yaml_writer.py` to reflect the new `resolution`, which is the diameter of each obstacle, as well as the `origin`, whose current value of 4.5 will need to change to `-1 * number of rows * diameter of cylinders`.
 Once all the environments are generated, use normalize_metrics.py to normalize the values of the calculated metrics. This script will generate 300 more files with the normalized metric values in the norm_metrics_files folder.
 
+```console
+$ python normalize_metrics.py
+```
 
 ## BARN Dataset structure
 The dataset files will be saved in the test_data folder. The folder called cspace_files contains .npy files with a 30x30 occupancy grid of the C-space. The grid_files folder will contain the occupancy grid of the world in .npy format. The map_files folder contains pgm and yaml files for use with ROS map_server. The

--- a/difficulty_quant.py
+++ b/difficulty_quant.py
@@ -1,5 +1,10 @@
 import math
-import Queue
+try:
+    # Python 3
+    from queue import PriorityQueue
+except ImportError:
+    # Python 2
+    from Queue import PriorityQueue
 import numpy as np
   
 class DifficultyMetrics:
@@ -186,7 +191,7 @@ class DifficultyMetrics:
   # returns the distance to the closest obstacle at point (r, c)
   # returns 0 if self.map[r][c] is an obstacle, 1 if an adjacent non-diagonal cell is an obstacle, etc.
   def _dist_closest_wall(self, r, c):
-    pq = Queue.PriorityQueue()
+    pq = PriorityQueue()
     first_wrapper = self.Wrapper(0, r, c)
     pq.put(first_wrapper)
     visited = {(r, c) : first_wrapper}

--- a/gen_world_ca.py
+++ b/gen_world_ca.py
@@ -1,10 +1,20 @@
 import random
 import datetime
-import Queue
+try:
+    # Python 3
+    from queue import Queue
+except ImportError:
+    # Python 2
+    from Queue import Queue
 import math
 
 import matplotlib.pyplot as plt
-import Tkinter as tk
+try:
+    # Python 3
+    import tkinter as tk
+except ImportError:
+    # Python 2
+    import Tkinter as tk
 import numpy as np
 
 from world_writer import WorldWriter
@@ -114,7 +124,7 @@ class JackalMap:
 
   # use flood-fill algorithm to find the open region including (r, c)
   def _get_region(self, r, c):
-    queue = Queue.Queue(maxsize=0)
+    queue = Queue(maxsize=0)
     
     # region is 2D array that indicates the open region connected to (r, c) with a 1
     region = [[0 for i in range(self.cols)] for j in range(self.rows)]
@@ -168,6 +178,9 @@ class JackalMap:
     return max_region
 
   def regions_connected(self, regionA, regionB):
+    if len(regionB) != len(regionA):
+      # Sometimes one of the regions can be empty
+      return False
     for r in range(len(regionA)):
       for c in range(len(regionA[0])):
         if regionA[r][c] != regionB[r][c]:
@@ -373,7 +386,7 @@ class AStarSearch:
   def return_path(self, end_node):
     path = []
     curr_node = end_node
-    while curr_node != None:
+    while curr_node is not None:
       path.append((curr_node.r, curr_node.c))
       curr_node = curr_node.parent
 
@@ -593,6 +606,7 @@ def main(iteration=0, seed=0, smooth_iter=4, fill_pct=.27, rows=30, cols=30, sho
 
     # throw out any maps that don't have a path
     if not jmap_gen.regions_connected(start_region, end_region):
+      print("Start and end regions don't connect")
       return
 
     # get the final Jackal Map (C-space)

--- a/generator.py
+++ b/generator.py
@@ -15,8 +15,8 @@ def main():
     for smooths in range(2, 5):
       param_counter = 0
       while param_counter < set_size:
-	print('_________________________________________________________')
-	print('world', total_counter, 'fill_pct', fill_pct, 'smooths', smooths)
+        print('_________________________________________________________')
+        print('world', total_counter, 'fill_pct', fill_pct, 'smooths', smooths)
         result = gen_world_ca.main(total_counter, hash(datetime.datetime.now()), smooths, fill_pct, show_metrics=0)
         if result: # worlds with no path are not counted or used
           param_counter += 1

--- a/pgm_writer.py
+++ b/pgm_writer.py
@@ -45,12 +45,15 @@ class PGMWriter():
         # open file for writing
         try:
             fout=open(self.filename, 'wb')
-        except IOError, er:
+        except (IOError, er):
             sys.exit()
 
 
         # define PGM Header
-        pgm_header = 'P5' + '\n' + str(width) + '  ' + str(height) + '  ' + str(255) + '\n'
+        if sys.version_info < (3,):
+            pgm_header = 'P5' + '\n' + str(width) + '  ' + str(height) + '  ' + str(255) + '\n'
+        else:
+            pgm_header = 'P5\n{w}  {h}  255\n'.format(w=width, h=height).encode('ascii')
 
         # write the header to the file
         fout.write(pgm_header)


### PR DESCRIPTION
This makes the scripts compatible with Python 3, while keeping Python 2.7 compatibility.

I tested this PR by opening a few of the generated worlds in Gazebo 11. I  ran `gen_world_ca.py`, `generator.py`, and `normalize_metrics.py` with Python 2.7 and Python 3.10 and can confirm the scripts generate working worlds with both Python versions.