### PR TITLE
Index out of range error fixed in non-connected regions when searching for a valid path

### DIFF
--- a/gen_world_ca.py
+++ b/gen_world_ca.py
@@ -144,7 +144,7 @@ class JackalMap:
   # returns the largest contiguous region with a tile in the leftmost column
   def biggest_left_region(self):
     max_size = 0
-    max_region = []
+    max_region = [[0 for i in range(self.cols)] for j in range(self.rows)]
     for row in range(self.rows):
       region, size = self._get_region(row, 0)
 
@@ -157,7 +157,7 @@ class JackalMap:
   # returns the largest contiguous region with a tile in the rightmost column
   def biggest_right_region(self):
     max_size = 0
-    max_region = []
+    max_region = [[0 for i in range(self.cols)] for j in range(self.rows)]
     for row in range(self.rows):
       region, size = self._get_region(row, self.cols-1)
 
@@ -692,4 +692,4 @@ def main(iteration=0, seed=0, smooth_iter=4, fill_pct=.27, rows=30, cols=30, sho
     
 
 if __name__ == "__main__":
-    main(iteration = -1, seed=0, fill_pct=0.2, smooth_iter=4)
+    main(iteration = -1, seed=0, fill_pct=0.35, smooth_iter=4)

--- a/gen_world_ca.py
+++ b/gen_world_ca.py
@@ -692,4 +692,4 @@ def main(iteration=0, seed=0, smooth_iter=4, fill_pct=.27, rows=30, cols=30, sho
     
 
 if __name__ == "__main__":
-    main(iteration = -1, seed=0, fill_pct=0.35, smooth_iter=4)
+    main(iteration = -1, seed=0, fill_pct=0.30, smooth_iter=4)


### PR DESCRIPTION
While using gen_world_ca.py to generate a world with a fill percentage of 0.30 (or close), I encountered the following error:

Traceback (most recent call last):
  File "gen_world_ca.py", line 695, in <module>
    main(iteration = -1, seed=0, fill_pct=0.30, smooth_iter=4)
  File "gen_world_ca.py", line 595, in main
    if not jmap_gen.regions_connected(start_region, end_region):
  File "gen_world_ca.py", line 173, in regions_connected
    if regionA[r][c] != regionB[r][c]:
IndexError: list index out of range

This error occurs when there is no valid region connecting the left and right regions, resulting in an empty list. Attempting to index this empty list causes the error.

To fix this, I initialized the max_region variable in the functions biggest_left_region and biggest_right_region as a matrix filled with zeros. After executing the code many times, this error seems to be fixed.